### PR TITLE
:bug: pass additional props to splide slide

### DIFF
--- a/src/js/components/SplideSlide.jsx
+++ b/src/js/components/SplideSlide.jsx
@@ -13,9 +13,9 @@ import { classNames } from "../utils";
  *
  * @param {Object} props - Props.
  */
-export default ( { children, className } ) => {
+export default ( { children, className, ...props } ) => {
 	return (
-		<li className={ classNames( 'splide__slide', className ) }>
+		<li className={ classNames( 'splide__slide', className ) } {...props}>
 			{ children }
 		</li>
 	);


### PR DESCRIPTION
Fixes Extension props (e.g. data-splide-youtube) not being passed down to SplideSlide.

Relates to Issue [https://github.com/Splidejs/splide/issues/218](https://github.com/Splidejs/splide/issues/218)