### PR TITLE
allow export of dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     },
     "./css": "./dist/css/splide.min.css",
     "./css/core": "./dist/css/splide-core.min.css",
-    "./css/*": "./dist/css/themes/splide-*.min.css"
+    "./css/*": "./dist/css/themes/splide-*.min.css",
+    "./dist/": "./dist/"
   },
   "dependencies": {
     "@splidejs/splide": "^4.1.3"


### PR DESCRIPTION
fix the issue that happen when you need to import the css file as object.
<!--
  Please make sure to add a new issue before you send PR!
-->

## Related Issues

https://github.com/remix-run/remix/discussions/4068

## Description
This fix just copy the setting of the vanilla splidejs -> [package.json](https://github.com/Splidejs/splide/blob/master/package.json#L108)
