### PR TITLE
Could not find a declaration file for module '@splidejs/react-splide' Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     ".": {
       "require": "./dist/js/react-splide.cjs.js",
       "import": "./dist/js/react-splide.esm.js",
-      "default": "./dist/js/react-splide.esm.js"
+      "default": "./dist/js/react-splide.esm.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./css": "./dist/css/splide.min.css",
     "./css/core": "./dist/css/splide-core.min.css",


### PR DESCRIPTION
Typescript import error fix. The type declaration is not found for the module

<!--
  Please make sure to add a new issue before you send PR!
-->

## Related Issues
https://github.com/Splidejs/react-splide/issues/84

<!--
  Link to the issue
-->

## Description
The module's type declaration file was not detected during import. This fixes the issue by updating the path of types in the  pacakage.json.
<!-- Write a brief description here -->
